### PR TITLE
【Task.6-3 model の validation テストの実装】

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -17,4 +17,6 @@ class Article < ApplicationRecord
   belongs_to :user
   has_many :comments, dependent: :destroy
   has_many :article_likes, dependent: :destroy
+
+  validates :title, presence: true
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -22,4 +22,6 @@
 class Comment < ApplicationRecord
   belongs_to :user
   belongs_to :article
+
+  validates :body, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,13 +31,15 @@
 #  index_users_on_uid_and_provider      (uid,provider) UNIQUE
 #
 class User < ApplicationRecord
-  has_many :articles, dependent: :destroy
-  has_many :comments, dependent: :destroy
-  has_many :article_likes, dependent: :destroy
-
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   include DeviseTokenAuth::Concerns::User
+
+  has_many :articles, dependent: :destroy
+  has_many :comments, dependent: :destroy
+  has_many :article_likes, dependent: :destroy
+
+  validates :name, presence: true
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :user do
+    name { Faker::Name.name }
+    sequence(:email) {|n| "#{n}_#{Faker::Internet.email}" }
+    password {|n| "#{n}_#{Faker::Internet.password}" }
+  end
+end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -16,5 +16,21 @@
 require "rails_helper"
 
 RSpec.describe Article, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let!(:user) { build(:user) }
+
+  context "必要な情報が揃っている場合" do
+    let(:article) { build(:article, title: "テスト", content: "テスト", user: user) }
+
+    it "記事が作成される" do
+      expect(article).to be_valid
+    end
+  end
+
+  context "タイトルがないとき" do
+    let(:article) { build(:article, title: nil, user: user) }
+
+    it "エラーが発生する" do
+      expect(article).not_to be_valid
+    end
+  end
 end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -22,5 +22,22 @@
 require "rails_helper"
 
 RSpec.describe Comment, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let!(:user) { build(:user) }
+  let!(:article) { build(:article, title: "テスト", content: "テスト", user: user) }
+
+  context "必要な情報が揃っている場合" do
+    let(:comment) { build(:comment, body: "テスト", user: user, article: article) }
+
+    it "コメント投稿できる" do
+      expect(comment).to be_valid
+    end
+  end
+
+  context "body がない場合" do
+    let(:comment) { build(:comment, body: nil, user: user, article: article) }
+
+    it "エラーが発生する" do
+      expect(comment).not_to be_valid
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe User, type: :model do
+  context "必要な情報が揃っている場合" do
+    let(:user) { build(:user) }
+
+    it "ユーザー登録できる" do
+      expect(user).to be_valid
+    end
+  end
+
+  context "名前のみ入力している場合" do
+    let(:user) { build(:user, email: nil, password: nil) }
+
+    it "エラーが発生する" do
+      expect(user).not_to be_valid
+    end
+  end
+
+  context "email がない場合" do
+    let(:user) { build(:user, email: nil) }
+
+    it "エラーが発生する" do
+      expect(user).not_to be_valid
+    end
+  end
+
+  context "password がない場合" do
+    let(:user) { build(:user, password: nil) }
+
+    it "エラーが発生する" do
+      expect(user).not_to be_valid
+    end
+  end
+end


### PR DESCRIPTION
## 概要
- 各モデルにバリデーションを追加してテストを実装。

## 内容
- user モデルにバリデーション追加してテストを簡単に実装
  - email, password に関するバリデーションは devise_token_auth のデフォルトを使用することとした。
- article モデルにバリデーション追加してテストを簡単に実装
- comment モデルにバリデーション追加してテストを簡単に実装