### PR TITLE
【Task.7-3 記事一覧の実装】

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,0 +1,8 @@
+module Api::V1
+  class ArticlesController < BaseApiController
+    def index
+      articles = Article.all.order(updated_at: :desc)
+      render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
+    end
+  end
+end

--- a/app/serializers/api/v1/article_preview_serializer.rb
+++ b/app/serializers/api/v1/article_preview_serializer.rb
@@ -1,0 +1,5 @@
+class Api::V1::ArticlePreviewSerializer < ActiveModel::Serializer
+  attributes :id, :title, :updated_at
+
+  belongs_to :user, serializer: Api::V1::UserSerializer
+end

--- a/app/serializers/api/v1/user_serializer.rb
+++ b/app/serializers/api/v1/user_serializer.rb
@@ -1,0 +1,3 @@
+class Api::V1::UserSerializer < ActiveModel::Serializer
+  attributes :id, :name, :email
+end

--- a/config/rubocop/rspec.yml
+++ b/config/rubocop/rspec.yml
@@ -60,3 +60,11 @@ RSpec/NestedGroups:
 # ブロックの方が見た目がスッキリして見やすいので、どちらでもお好きにどうぞ。
 RSpec/ReturnFromStub:
   Enabled: false
+
+# 複数の expect に対する警告を無効に
+RSpec/MultipleExpectations:
+  Enabled: false
+
+
+RSpec/LetSetup:
+  Enabled: false

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -15,7 +15,8 @@
 #
 FactoryBot.define do
   factory :article do
-    title { "MyString" }
-    content { "MyText" }
+    title { Faker::Lorem.word }
+    content { Faker::Lorem.sentence }
+    user
   end
 end

--- a/spec/requests/articles_request_spec.rb
+++ b/spec/requests/articles_request_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe "Articles", type: :request do
+  describe "GET /articles" do
+    subject { get(api_v1_articles_path) }
+
+    let!(:article1) { create(:article, updated_at: 3.days.ago) }
+    let!(:article2) { create(:article, updated_at: 1.days.ago) }
+    let!(:article3) { create(:article) }
+
+    it "記事の一覧が取得できる" do
+      subject
+      res = JSON.parse(response.body)
+
+      expect(res.length).to eq 3
+      expect(res[0].keys).to eq ["id", "title", "updated_at", "user"]
+      expect(response).to have_http_status(200)
+    end
+  end
+end

--- a/spec/requests/articles_request_spec.rb
+++ b/spec/requests/articles_request_spec.rb
@@ -4,9 +4,7 @@ RSpec.describe "Articles", type: :request do
   describe "GET /articles" do
     subject { get(api_v1_articles_path) }
 
-    let!(:article1) { create(:article, updated_at: 3.days.ago) }
-    let!(:article2) { create(:article, updated_at: 1.days.ago) }
-    let!(:article3) { create(:article) }
+    before { create_list(:article, 3) }
 
     it "記事の一覧が取得できる" do
       subject


### PR DESCRIPTION
## 概要
- 記事の一覧取得に関する機能とテストを実装

## 内容
- シリアライザーを作成
- 記事の `index`アクションとテストを実装
- 記事に関する FactoryBot の設定を追加