### PR TITLE
【Task. 7-7 記事削除の実装】

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -23,6 +23,11 @@ module Api::V1
       render json: article, serializer: Api::V1::ArticleSerializer
     end
 
+    def destroy
+      article = current_user.articles.find(params[:id])
+      article.destroy!
+    end
+
     private
 
       def article_params

--- a/spec/requests/articles_request_spec.rb
+++ b/spec/requests/articles_request_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe "Articles", type: :request do
 
       it "削除できない" do
         expect { subject }.to raise_error(ActiveRecord::RecordNotFound) &
-                              change { Article.count }.by(0)
+                              not_change { Article.count }
       end
     end
   end

--- a/spec/requests/articles_request_spec.rb
+++ b/spec/requests/articles_request_spec.rb
@@ -90,4 +90,30 @@ RSpec.describe "Articles", type: :request do
       end
     end
   end
+
+  describe "DELETE /articles/:id" do
+    subject { delete(api_v1_article_path(article.id)) }
+
+    let(:current_user) { create(:user) }
+    before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+
+    context "自分が所持している記事を削除しようとするとき" do
+      let!(:article) { create(:article, user: current_user) }
+
+      it "削除できる" do
+        expect { subject }.to change { Article.count }.by(-1)
+        expect(response).to have_http_status(204)
+      end
+    end
+
+    context "自分が所持していない記事を削除しようとするとき" do
+      let(:other_user) { create(:user) }
+      let!(:article) { create(:article, user: other_user) }
+
+      it "削除できない" do
+        expect { subject }.to raise_error(ActiveRecord::RecordNotFound) &
+                              change { Article.count }.by(0)
+      end
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -89,4 +89,6 @@ RSpec.configure do |config|
   #   # test failures related to randomization by passing the same `--seed` value
   #   # as the one that triggered the failure.
   #   Kernel.srand config.seed
+
+  RSpec::Matchers.define_negated_matcher :not_change, :change
 end


### PR DESCRIPTION
## 概要
- 記事の削除機能とテストを実装

## 補足
- change matcher の否定形である not_change を定義

