### PR TITLE
【Task. 9-5 既存 API の修正】

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,5 +1,7 @@
 module Api::V1
   class ArticlesController < BaseApiController
+    before_action :authenticate_user!, only: [:create, :update, :destroy]
+
     def index
       articles = Article.all.order(updated_at: :desc)
       render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::BaseApiController < ApplicationController
-  def current_user
-    @current_user ||= User.first
-  end
+  alias_method :current_user, :current_api_v1_user
+  alias_method :authenticate_user!, :authenticate_api_v1_user!
+  alias_method :user_signed_in?, :api_v1_user_signed_in?
 end

--- a/spec/requests/articles_request_spec.rb
+++ b/spec/requests/articles_request_spec.rb
@@ -46,13 +46,12 @@ RSpec.describe "Articles", type: :request do
   end
 
   describe "POST /articles" do
-    subject { post(api_v1_articles_path, params: params) }
+    subject { post(api_v1_articles_path, params: params, headers: headers) }
 
     context "適切なパラメーターを送信したとき" do
       let(:params) { { article: attributes_for(:article) } }
       let(:current_user) { create(:user) }
-
-      before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+      let(:headers) { current_user.create_new_auth_token }
 
       it "記事が作成できる" do
         expect { subject }.to change { Article.count }.by(1)
@@ -65,11 +64,11 @@ RSpec.describe "Articles", type: :request do
   end
 
   describe "PATCH(PUT) /articles/:id" do
-    subject { patch(api_v1_article_path(article.id), params: params) }
+    subject { patch(api_v1_article_path(article.id), params: params, headers: headers) }
 
     let(:params) { { article: attributes_for(:article) } }
     let(:current_user) { create(:user) }
-    before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+    let(:headers) { current_user.create_new_auth_token }
 
     context "自分が所持している記事のレコードを更新しようとするとき" do
       let(:article) { create(:article, user: current_user) }
@@ -92,10 +91,10 @@ RSpec.describe "Articles", type: :request do
   end
 
   describe "DELETE /articles/:id" do
-    subject { delete(api_v1_article_path(article.id)) }
+    subject { delete(api_v1_article_path(article.id), headers: headers) }
 
     let(:current_user) { create(:user) }
-    before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+    let(:headers) { current_user.create_new_auth_token }
 
     context "自分が所持している記事を削除しようとするとき" do
       let!(:article) { create(:article, user: current_user) }


### PR DESCRIPTION
## 概要
- stub で作った仮実装を devise_token_auth の機能を反映した内容に修正

## 内容
- devise_token_auth のヘルパーメソッドをエイリアスを指定してそれぞれ反映
- articles_controller 特定の API を認証済のユーザー以外はアクセスできないようにする
- 上記内容をふまえて、記事の spec ファイルを修正