### PR TITLE
【Task. 11-1 Article model に下書き機能を追加】

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -4,6 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  body       :text
+#  status     :integer
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -4,7 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  body       :text
-#  status     :integer
+#  status     :integer          default("draft")
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
@@ -20,4 +20,6 @@ class Article < ApplicationRecord
   has_many :article_likes, dependent: :destroy
 
   validates :title, presence: true
+
+  enum status: { draft: 0, published: 1 }
 end

--- a/db/migrate/20250214164507_add_status_to_articles.rb
+++ b/db/migrate/20250214164507_add_status_to_articles.rb
@@ -1,0 +1,5 @@
+class AddStatusToArticles < ActiveRecord::Migration[6.1]
+  def change
+    add_column :articles, :status, :integer
+  end
+end

--- a/db/migrate/20250214164507_add_status_to_articles.rb
+++ b/db/migrate/20250214164507_add_status_to_articles.rb
@@ -1,5 +1,5 @@
 class AddStatusToArticles < ActiveRecord::Migration[6.1]
   def change
-    add_column :articles, :status, :integer
+    add_column :articles, :status, :integer, default: 0
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_01_28_132057) do
+ActiveRecord::Schema.define(version: 2025_02_14_164507) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,6 +30,7 @@ ActiveRecord::Schema.define(version: 2025_01_28_132057) do
     t.text "body"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "status"
     t.index ["user_id"], name: "index_articles_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -30,7 +30,7 @@ ActiveRecord::Schema.define(version: 2025_02_14_164507) do
     t.text "body"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.integer "status"
+    t.integer "status", default: 0
     t.index ["user_id"], name: "index_articles_on_user_id"
   end
 

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -4,6 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  body       :text
+#  status     :integer
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -4,7 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  body       :text
-#  status     :integer
+#  status     :integer          default("draft")
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
@@ -19,5 +19,13 @@ FactoryBot.define do
     title { Faker::Lorem.word }
     body { Faker::Lorem.sentence }
     user
+
+    trait :draft do
+      status { :draft }
+    end
+
+    trait :published do
+      status { :published }
+    end
   end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -4,7 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  body       :text
-#  status     :integer
+#  status     :integer          default("draft")
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
@@ -17,18 +17,37 @@
 require "rails_helper"
 
 RSpec.describe Article, type: :model do
-  let!(:user) { build(:user) }
+  describe "正常系" do
+    context "タイトルと本文が入力されているとき" do
+      let(:article) { build(:article) }
 
-  context "必要な情報が揃っている場合" do
-    let(:article) { build(:article, title: "テスト", body: "テスト", user: user) }
+      it "下書きが保存できる" do
+        expect(article).to be_valid
+        expect(article.status).to eq "draft"
+      end
+    end
 
-    it "記事が作成される" do
-      expect(article).to be_valid
+    context "status が下書き状態のとき" do
+      let(:article) { build(:article, :draft) }
+
+      it "記事を下書き状態で作成できる" do
+        expect(article).to be_valid
+        expect(article.status).to eq "draft"
+      end
+    end
+
+    context "status が公開状態のとき" do
+      let(:article) { build(:article, :published) }
+
+      it "記事を公開状態で作成できる" do
+        expect(article).to be_valid
+        expect(article.status).to eq "published"
+      end
     end
   end
 
   context "タイトルがないとき" do
-    let(:article) { build(:article, title: nil, user: user) }
+    let(:article) { build(:article, title: nil) }
 
     it "エラーが発生する" do
       expect(article).not_to be_valid

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -4,6 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  body       :text
+#  status     :integer
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null


### PR DESCRIPTION
## 概要
- 記事の下書き機能を enum を使って実装
- Article model のテストを追加

## 内容
- Article model に status カラムを追加
- 記事作成時に、ステータスを任意の値に変更できるように調整
- 記事作成に関するテストを追加
- 記事の Factory に trait を追加