### PR TITLE
【Task. 11-2 既存のAPIの修正】

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -3,12 +3,12 @@ module Api::V1
     before_action :authenticate_user!, only: [:create, :update, :destroy]
 
     def index
-      articles = Article.all.order(updated_at: :desc)
+      articles = Article.published.order(updated_at: :desc)
       render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
     end
 
     def show
-      article = Article.find(params[:id])
+      article = Article.published.find(params[:id])
       render json: article, serializer: Api::V1::ArticleSerializer
     end
 
@@ -33,7 +33,7 @@ module Api::V1
     private
 
       def article_params
-        params.require(:article).permit(:title, :body)
+        params.require(:article).permit(:title, :body, :status)
       end
   end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -22,4 +22,6 @@ class Article < ApplicationRecord
   validates :title, presence: true
 
   enum status: { draft: 0, published: 1 }
+
+  scope :published, -> { where(status: :published) }
 end

--- a/app/serializers/api/v1/article_serializer.rb
+++ b/app/serializers/api/v1/article_serializer.rb
@@ -1,4 +1,4 @@
 class Api::V1::ArticleSerializer < ActiveModel::Serializer
-  attributes :id, :title, :body, :updated_at
+  attributes :id, :title, :body, :status, :updated_at
   belongs_to :user, serializer: Api::V1::UserSerializer
 end

--- a/spec/requests/articles_request_spec.rb
+++ b/spec/requests/articles_request_spec.rb
@@ -4,13 +4,18 @@ RSpec.describe "Articles", type: :request do
   describe "GET /articles" do
     subject { get(api_v1_articles_path) }
 
-    before { create_list(:article, 3) }
+    let!(:a_article) { create(:article, :published, updated_at: 1.days.ago) }
+    let!(:b_article) { create(:article, :published, updated_at: 3.days.ago) }
+    let!(:c_article) { create(:article, :published) }
 
-    it "記事の一覧が取得できる" do
+    before { create(:article, :draft) }
+
+    it "公開中の記事の一覧が取得できる" do
       subject
       res = JSON.parse(response.body)
 
       expect(res.length).to eq 3
+      expect(res.map {|article| article["id"] }).to eq([c_article.id, a_article.id, b_article.id])
       expect(res[0].keys).to eq ["id", "title", "updated_at", "user"]
       expect(response).to have_http_status(200)
     end
@@ -20,19 +25,30 @@ RSpec.describe "Articles", type: :request do
     subject { get(api_v1_article_path(article_id)) }
 
     context "指定した id の記事が存在するとき" do
-      let(:article) { create(:article) }
       let(:article_id) { article.id }
 
-      it "記事のレコードが取得できる" do
-        subject
-        res = JSON.parse(response.body)
-        expect(response).to have_http_status(200)
+      context "対象の記事が公開中の場合" do
+        let(:article) { create(:article, :published) }
 
-        expect(res["id"]).to eq article.id
-        expect(res["title"]).to eq article.title
-        expect(res["body"]).to eq article.body
-        expect(res["updated_at"]).to eq article.updated_at.strftime("%Y-%m-%dT%H:%M:%S.%3NZ")
-        expect(res["user"]["id"]).to eq article.user.id
+        it "任意の記事が取得できる" do
+          subject
+          res = JSON.parse(response.body)
+          expect(response).to have_http_status(200)
+
+          expect(res["id"]).to eq article.id
+          expect(res["title"]).to eq article.title
+          expect(res["body"]).to eq article.body
+          expect(res["updated_at"]).to be_present
+          expect(res["user"]["id"]).to eq article.user.id
+        end
+      end
+
+      context "対象の記事が下書き状態の場合" do
+        let(:article) { create(:article, :draft) }
+
+        it "記事が見つからない" do
+          expect { subject }.to raise_error ActiveRecord::RecordNotFound
+        end
       end
     end
 
@@ -48,10 +64,11 @@ RSpec.describe "Articles", type: :request do
   describe "POST /articles" do
     subject { post(api_v1_articles_path, params: params, headers: headers) }
 
-    context "適切なパラメーターを送信したとき" do
-      let(:params) { { article: attributes_for(:article) } }
-      let(:current_user) { create(:user) }
-      let(:headers) { current_user.create_new_auth_token }
+    let(:current_user) { create(:user) }
+    let(:headers) { current_user.create_new_auth_token }
+
+    context "公開指定で記事を作成するとき" do
+      let(:params) { { article: attributes_for(:article, :published) } }
 
       it "記事が作成できる" do
         expect { subject }.to change { Article.count }.by(1)
@@ -61,26 +78,46 @@ RSpec.describe "Articles", type: :request do
         expect(response).to have_http_status(200)
       end
     end
+
+    context "下書き指定で記事を作成するとき" do
+      let(:params) { { article: attributes_for(:article, :draft) } }
+
+      it "下書き記事が作成できる" do
+        expect { subject }.to change { Article.count }.by(1)
+        res = JSON.parse(response.body)
+        expect(res["status"]).to eq "draft"
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context "不適切なパラメータを送信したとき" do
+      let(:params) { { article: attributes_for(:article, status: "foo") } }
+
+      it "エラーする" do
+        expect { subject }.to raise_error ArgumentError
+      end
+    end
   end
 
   describe "PATCH(PUT) /articles/:id" do
     subject { patch(api_v1_article_path(article.id), params: params, headers: headers) }
 
-    let(:params) { { article: attributes_for(:article) } }
+    let(:params) { { article: attributes_for(:article, :published) } }
     let(:current_user) { create(:user) }
     let(:headers) { current_user.create_new_auth_token }
 
-    context "自分が所持している記事のレコードを更新しようとするとき" do
-      let(:article) { create(:article, user: current_user) }
+    context "自分の記事を更新するとき" do
+      let(:article) { create(:article, :draft, user: current_user) }
 
       it "更新できる" do
         expect { subject }.to change { article.reload.title }.from(article.title).to(params[:article][:title]) &
-                              change { article.reload.body }.from(article.body).to(params[:article][:body])
+                              change { article.reload.body }.from(article.body).to(params[:article][:body]) &
+                              change { article.reload.status }.from(article.status).to(params[:article][:status].to_s)
         expect(response).to have_http_status(200)
       end
     end
 
-    context "自分が所持していない記事のレコードを更新しようとするとき" do
+    context "他のユーザーの記事を更新しようとするとき" do
       let(:other_user) { create(:user) }
       let!(:article) { create(:article, user: other_user) }
 


### PR DESCRIPTION
## 概要
- 記事一覧で公開中の記事だけを取得できるように修正
- 記事作成 / 更新時に、公開 / 非公開を選択できるように修正
