### PR TITLE
【Task. 11-3 下書き記事の一覧/詳細 のAPI実装】

### DIFF
--- a/app/controllers/api/v1/articles/drafts_controller.rb
+++ b/app/controllers/api/v1/articles/drafts_controller.rb
@@ -1,0 +1,15 @@
+module Api::V1
+  class Articles::DraftsController < BaseApiController
+    before_action :authenticate_user!, only: [:index, :show]
+
+    def index
+      articles = current_user.articles.draft.order(updated_at: :desc)
+      render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
+    end
+
+    def show
+      article = current_user.articles.draft.find(params[:id])
+      render json: article, serializer: Api::V1::ArticleSerializer
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,9 @@ Rails.application.routes.draw do
       mount_devise_token_auth_for "User", at: "auth", controllers: {
         registrations: "api/v1/auth/registrations",
       }
+      namespace :articles do
+        resources :drafts, only: [:index, :show]
+      end
       resources :articles
     end
   end

--- a/spec/requests/api/v1/articles/drafts_request_spec.rb
+++ b/spec/requests/api/v1/articles/drafts_request_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Articles::Drafts", type: :request do
+  let(:current_user) { create(:user) }
+  let(:headers) { current_user.create_new_auth_token }
+
+  describe "GET /api/v1/articles/drafts" do
+    subject { get(api_v1_articles_drafts_path, headers: headers) }
+
+    context "自分の書いた下書き記事が存在するとき" do
+      let!(:a_article) { create(:article, :draft, user: current_user) }
+      let!(:b_article) { create(:article, :draft) }
+
+      it "自分の書いた下書き記事の一覧のみが取得できる" do
+        subject
+        res = JSON.parse(response.body)
+
+        expect(response).to have_http_status(200)
+        expect(res.length).to eq 1
+        expect(res[0]["id"]).to eq a_article.id
+        expect(res[0].keys).to eq ["id", "title", "updated_at", "user"]
+        expect(res[0]["user"].keys).to eq ["id", "name", "email"]
+      end
+    end
+  end
+
+  describe "GET /api/v1/articles/drafts/:id" do
+    subject { get(api_v1_articles_draft_path(article_id), headers: headers) }
+
+    context "指定した id の記事が存在して" do
+      let(:article_id) { article.id }
+
+      context "対象の記事が自分が書いた下書きのとき" do
+        let(:article) { create(:article, :draft, user: current_user) }
+
+        it "記事の詳細を取得できる" do
+          subject
+          res = JSON.parse(response.body)
+
+          expect(response).to have_http_status(200)
+          expect(res["id"]).to eq article.id
+          expect(res["title"]).to eq article.title
+          expect(res["body"]).to eq article.body
+          expect(res["status"]).to eq article.status
+          expect(res["updated_at"]).to be_present
+          expect(res["user"]["id"]).to eq article.user.id
+          expect(res["user"].keys).to eq ["id", "name", "email"]
+        end
+      end
+
+      context "対象の記事が他のユーザーが書いた下書きのとき" do
+        let(:article) { create(:article, :draft) }
+
+        it "記事が見つからない" do
+          expect { subject }.to raise_error ActiveRecord::RecordNotFound
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/articles/drafts_request_spec.rb
+++ b/spec/requests/api/v1/articles/drafts_request_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe "Api::V1::Articles::Drafts", type: :request do
       context "対象の記事が自分が書いた下書きのとき" do
         let(:article) { create(:article, :draft, user: current_user) }
 
+        # rubocop:disable RSpec/ExampleLength
         it "記事の詳細を取得できる" do
           subject
           res = JSON.parse(response.body)
@@ -46,6 +47,7 @@ RSpec.describe "Api::V1::Articles::Drafts", type: :request do
           expect(res["user"]["id"]).to eq article.user.id
           expect(res["user"].keys).to eq ["id", "name", "email"]
         end
+        # rubocop:enable RSpec/ExampleLength
       end
 
       context "対象の記事が他のユーザーが書いた下書きのとき" do


### PR DESCRIPTION
## 概要
- 下書きに関する記事の一覧 / 詳細を取得する API を実装